### PR TITLE
Add app.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,22 @@ The intend of this project is to create an API (possibly in **Python**) which wi
 # Status
 
 We are in the early phase of the project and framework, architectural and other decisions haven't been taken yet. Please help discussing them in the GitHub **Issues** section of this project.
+
+# Project setup
+First, create a virtualenv, activate it, and then install the dependencies:
+
+```
+python -m venv env
+source ./env/bin/activate
+pip install -r requirements.txt
+```
+
+Then run the app with:
+
+```
+uvicorn covidapi.app:app --reload
+```
+
+The API will be served at [http://localhost:8000/](http://localhost:8000/)
+
+The API docs are served at [http://localhost:8000/docs](http://localhost:8000/docs)

--- a/covidapi/app.py
+++ b/covidapi/app.py
@@ -1,0 +1,3 @@
+from fastapi import FastAPI
+
+app = FastAPI()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.50.0
 pydantic==1.4
 SQLAlchemy==1.3.13
+uvicorn==0.11.3


### PR DESCRIPTION
Now that the db stuff is merged, I thought a logical next step is to start fleshing out the api part.

This adds app.py as an entry point to the application. At the moment this has no endpoints defined, so it just serves a 404 response, and minimal API documentation, but this should make it easier to start adding stuff.