### PR TITLE
Add /health and /daily-reports endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Data
+covid-reports.db

--- a/covidapi/api/views.py
+++ b/covidapi/api/views.py
@@ -1,0 +1,32 @@
+from fastapi import Depends
+from fastapi import APIRouter
+from sqlalchemy.orm import Session
+from typing import List
+
+from ..db import crud, models
+from ..db.schemas import DailyReport
+from ..db.database import SessionLocal, engine
+
+models.Base.metadata.create_all(bind=engine)
+
+router = APIRouter()
+
+
+# Dependency
+def get_db():
+    try:
+        db = SessionLocal()
+        yield db
+    finally:
+        db.close()
+
+
+@router.get('/v1/health')
+def health():
+    return {'status': 'ok'}
+
+
+@router.get("/v1/daily-reports/", response_model=List[DailyReport])
+def get_daily_reports(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    daily_reports = crud.get_daily_reports(db, skip=skip, limit=limit)
+    return daily_reports

--- a/covidapi/app.py
+++ b/covidapi/app.py
@@ -1,3 +1,5 @@
 from fastapi import FastAPI
+from .api import views
 
 app = FastAPI()
+app.include_router(views.router)

--- a/covidapi/db/schemas.py
+++ b/covidapi/db/schemas.py
@@ -1,9 +1,10 @@
 from pydantic import BaseModel
 from datetime import datetime
+from typing import Optional
 
 
 class DailyReport(BaseModel):
-    id: int
+    id: Optional[int]
     country_region: str
     province_state: str
     last_update: datetime


### PR DESCRIPTION
Hi everyone!

This PR adds two simple but working endpoints:
- /v1/health
- /v1/daily-reports

here is an example of the returned data:

<img width="570" alt="Screenshot 2020-03-03 18 12 39" src="https://user-images.githubusercontent.com/636391/75801423-69772d00-5d7b-11ea-9d19-6541d11d3cab.png">

There is a issue: to make it work I had to run `uvicorn covidapi.app:app --reload` from the root of the project **and** copy `covid-reports.db` from `covidapi/` to the root of the project.

If I try to run `uvicorn app:app --reload` from inside `covidapi/` folder, I start getting errors like this:

```
  File "./app.py", line 2, in <module>
    from .api import views
ImportError: attempted relative import with no known parent package
```

We can definitely improve this but I think it's at least "something". What do you think? If you have any suggestions, please let me know!