### PR TITLE
Use postgres for the db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Data
 covid-reports.db
+
+# Postgres database files if running in docker
+tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3
+WORKDIR /covidapi
+COPY requirements.txt /covidapi/
+COPY requirements-test.txt /covidapi/
+RUN pip install -r /covidapi/requirements.txt
+RUN pip install -r /covidapi/requirements-test.txt
+
+CMD ["uvicorn", "covidapi.app:app", "--host", "0.0.0.0", "--reload"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,22 @@ source ./env/bin/activate
 pip install -r requirements.txt
 ```
 
-Then run the app with:
+You will need a postgres database to run the application.
+If you have [docker](https://docs.docker.com/get-started/) installed, then you can create a database by running
+
+```
+docker-compose up
+```
+
+To import the data, run
+
+```
+cd covidapi
+python import_data.py
+cd ..
+```
+
+Then you can run the app with:
 
 ```
 uvicorn covidapi.app:app --reload

--- a/README.md
+++ b/README.md
@@ -8,7 +8,26 @@ The intent of this project is to create an API which will make easier to access 
 We are in the early phase of the project and framework, architectural and other decisions haven't been taken yet. Please help discussing them in the GitHub **Issues** section of this project.
 
 # Project setup
-First, create a virtualenv, activate it, and then install the dependencies:
+
+## Postgres database
+You will need a postgres database to run the application.
+If you have [docker](https://docs.docker.com/get-started/) installed, then you can create a database by running
+
+```
+docker-compose up db
+```
+
+This creates an empty database called `covidapi`, and a user called `covidapi` with password `dummypassword`.
+
+## Running the app through docker
+If you run `docker-compose up` instead of `docker-compose up db`, the whole app will be run inside docker as well.
+
+The first time you do this you will need to run `docker-compose exec app python /covidapi/covidapi/import_data.py` to import the data.
+
+## Running the app directly
+To run the app directly you will need python 3.7 or later.
+
+Create a virtualenv, activate it, and then install the dependencies:
 
 ```
 python -m venv env
@@ -16,19 +35,10 @@ source ./env/bin/activate
 pip install -r requirements.txt
 ```
 
-You will need a postgres database to run the application.
-If you have [docker](https://docs.docker.com/get-started/) installed, then you can create a database by running
-
-```
-docker-compose up
-```
-
 To import the data, run
 
 ```
-cd covidapi
-python import_data.py
-cd ..
+python covidapi/import_data.py
 ```
 
 Then you can run the app with:
@@ -37,6 +47,7 @@ Then you can run the app with:
 uvicorn covidapi.app:app --reload
 ```
 
+## Viewing the API
 The API will be served at [http://localhost:8000/](http://localhost:8000/)
 
 The API docs are served at [http://localhost:8000/docs](http://localhost:8000/docs)

--- a/covidapi/db/database.py
+++ b/covidapi/db/database.py
@@ -1,12 +1,12 @@
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from os import environ
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./covid-reports.db"
-# SQLALCHEMY_DATABASE_URL = "postgresql://user:password@postgresserver/db"
+SQLALCHEMY_DATABASE_URL = environ.get("DATABASE_URL", "postgresql://covidapi:dummypassword@localhost:5432/covidapi")
 
 engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+    SQLALCHEMY_DATABASE_URL
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/covidapi/import_data.py
+++ b/covidapi/import_data.py
@@ -2,6 +2,9 @@ import csv
 from db.models import DailyReport
 from db.database import SessionLocal, engine, Base
 from datetime import datetime
+from pathlib import Path
+
+CSV_FILE = Path(__file__).parent / '02-29-2020.csv'
 
 
 def main():
@@ -10,7 +13,7 @@ def main():
     Base.metadata.create_all(engine)
     db_instance = SessionLocal()
 
-    with open('02-29-2020.csv') as csv_file:
+    with open(CSV_FILE) as csv_file:
         csv_reader = csv.reader(csv_file, delimiter=',')
         next(csv_reader, None)  # skip the headers
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  db:
+    image: postgres
+    volumes:
+      - ./tmp/db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=dummypassword
+      - POSTGRES_USER=covidapi
+    ports:
+      - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,14 @@ services:
       - POSTGRES_USER=covidapi
     ports:
       - "5432:5432"
+
+  app:
+    build: .
+    volumes:
+      - .:/covidapi
+    depends_on:
+      - db
+    environment:
+      - DATABASE_URL=postgresql://covidapi:dummypassword@db:5432/covidapi
+    ports:
+      - "8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:
-    image: postgres
+    image: postgres:12.2
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
     environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.50.0
 pydantic==1.4
 SQLAlchemy==1.3.13
 uvicorn==0.11.3
+psycopg2-binary==2.8.4


### PR DESCRIPTION
This PR swaps sqlite for postgres. I've also used [docker compose](https://docs.docker.com/compose/) to manage the dependency on postgres.

In theory this means that if you have docker installed you should just be able to run `docker-compose up` to get a working version of the app.

The database url is now passed in as an environment variable, which means that when we deploy to heroku, it should automatically pick up the right configuration. If not specified, it defaults to `postgresql://covidapi:dummypassword@localhost:5432/covidapi` which is what will get created for you if you spin up the docker database.