### PR TITLE
Deploy to Heroku after a PR is merged to master (fixes #34)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   python: circleci/python@0.2.1
+  heroku: circleci/heroku@1.0.1
 
 executors:
   covidapi-test:
@@ -37,3 +38,9 @@ workflows:
   main:
     jobs:
       - build-and-test
+      - heroku/deploy-via-git:
+           requires:
+             - build-and-test # only run deploy-via-git job if the build job has completed
+           filters:
+             branches:
+               only: master


### PR DESCRIPTION
With this configuration we are deploying the latest `master` branch to Heroku, whenever a pull request is merged and only if the build and tests are passing on CircleCI.