### PR TITLE
Add query string support for /v1/jh/daily-reports endpoint

### DIFF
--- a/covidapi/api/views.py
+++ b/covidapi/api/views.py
@@ -3,6 +3,7 @@ from fastapi import Depends
 from fastapi import APIRouter
 from starlette.responses import HTMLResponse
 from typing import List
+from datetime import date
 
 from ..services.crud import JHCRUD
 from ..services.session import get_db, Session
@@ -22,6 +23,19 @@ def health():
 
 
 @router.get("/v1/jh/daily-reports/", response_model=List[JHDailyReport])
-def get_daily_reports(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
-    daily_reports = JHCRUD().get_daily_reports(db, skip=skip, limit=limit)
+def get_daily_reports(
+    skip: int = 0, limit: int = 100, db: Session = Depends(get_db),
+    last_update_from: date = None,
+    last_update_to: date = None,
+    country: str = None,
+    province: str = None,
+):
+    daily_reports = JHCRUD().get_daily_reports(
+        db, skip=skip, limit=limit,
+        last_update_from=last_update_from,
+        last_update_to=last_update_to,
+        country=country,
+        province=province,
+    )
+
     return daily_reports

--- a/covidapi/schemas/schemas.py
+++ b/covidapi/schemas/schemas.py
@@ -7,6 +7,8 @@ class JHDailyReport(BaseModel):
     id: Optional[int]
     country_region: str
     province_state: Optional[str]
+    fips: Optional[str]
+    admin2: Optional[str]
     last_update: datetime
     confirmed: int
     deaths: int

--- a/covidapi/services/crud.py
+++ b/covidapi/services/crud.py
@@ -1,4 +1,5 @@
 from sqlalchemy.orm import Session
+from datetime import date
 
 from ..db import models
 from ..schemas import schemas
@@ -12,8 +13,26 @@ class JHCRUD:
                 models.JHDailyReport.id == daily_report_id
             ).first()
 
-    def get_daily_reports(self, db: Session, skip: int = 0, limit: int = 100):
-        return db.query(models.JHDailyReport).offset(skip).limit(limit).all()
+    def get_daily_reports(
+        self, db: Session, skip: int = 0, limit: int = 100,
+        last_update_from: date = None,
+        last_update_to: date = None,
+        country: str = None,
+        province: str = None,
+    ):
+        query = db.query(models.JHDailyReport)
+
+        if last_update_from:
+            query = query.filter(models.JHDailyReport.last_update >= last_update_from)
+        if last_update_to:
+            query = query.filter(models.JHDailyReport.last_update <= last_update_to)
+        if country:
+            query = query.filter(models.JHDailyReport.country_region == country)
+        if province:
+            query = query.filter(models.JHDailyReport.province_state == province)
+
+        query = query.offset(skip).limit(limit)
+        return query.all()
 
     def create_daily_report(self, db: Session, daily_report: schemas.JHDailyReport):
         db_daily_report = models.JHDailyReport(


### PR DESCRIPTION
This PR adds the following querystring parameters to the /v1/jh/daily-reports endpoint

- `last_update_from`: a `Date` parameter (ie: `2020-03-21`) wich will be used to search in JHDailyReport all the records `...WHERE last_update >= 2020-03-21`
- `last_update_to`: a `Date` parameter (ie: `2020-04-02`) wich will be used to search in JHDailyReport all the records `...WHERE last_update <= 2020-04-02`
- `country`: a `str` parameter (ie: `US`) wich will be used to search in JHDailyReport all the records `...WHERE country_region = 'US'`
- `province`: a `str` parameter (ie: `Los Angeles, CA`) wich will be used to search in JHDailyReport all the records `...WHERE country_region = 'Los Angeles, CA'`

Query example: `/v1/jh/daily-reports endpoint?last_update_from=2020-03-21&last_update_to=2020-04-02&country=US&province=Los Angeles, CA`