### PR TITLE
Change default rows limit to 1000

### DIFF
--- a/covidapi/api/views.py
+++ b/covidapi/api/views.py
@@ -24,7 +24,7 @@ def health():
 
 @router.get("/v1/jh/daily-reports/", response_model=List[JHDailyReport])
 def get_daily_reports(
-    skip: int = 0, limit: int = 100, db: Session = Depends(get_db),
+    skip: int = 0, limit: int = 1000, db: Session = Depends(get_db),
     last_update_from: date = None,
     last_update_to: date = None,
     country: str = None,

--- a/covidapi/services/crud.py
+++ b/covidapi/services/crud.py
@@ -14,7 +14,7 @@ class JHCRUD:
             ).first()
 
     def get_daily_reports(
-        self, db: Session, skip: int = 0, limit: int = 100,
+        self, db: Session, skip: int = 0, limit: int = 1000,
         last_update_from: date = None,
         last_update_to: date = None,
         country: str = None,


### PR DESCRIPTION
I'm still not sure how we should handle the `limit` parameter. By default is now `1000`, before it was `100`. The problem is:

- if we leave the limit on by default, the users may not know about it and they risk of not getting on the data
- if we leave it off by default they will get thousands of records

Probably the best option would be to implement pagination, but I've no idea how to do it with FastAPI. Maybe I should have a look.

Update: this doesn't look good 😓

<img width="907" alt="Screenshot 2020-04-05 21 20 57" src="https://user-images.githubusercontent.com/636391/78508161-154dd700-7785-11ea-842d-1142428840ac.png">
