### PR TITLE
Removing redundancy and optimizing Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM python:3
 WORKDIR /covidapi
-COPY requirements.txt /covidapi/
-COPY requirements-test.txt /covidapi/
-RUN pip install -r /covidapi/requirements.txt
-RUN pip install -r /covidapi/requirements-test.txt
+COPY requirements.txt requirements-test.txt /covidapi/
+RUN pip install -r /covidapi/requirements.txt -r /covidapi/requirements-test.txt
 
 CMD ["uvicorn", "covidapi.app:app", "--host", "0.0.0.0", "--reload"]


### PR DESCRIPTION
#### The following, seems to be minor, changes were made which will help as the project proceeds further to be complex in nature : 

* The COPY command in dockerfile can [accept multiple sources]( https://docs.docker.com/engine/reference/builder/#copy ) (`< src1 > < src2 > ... `) if the destination (`< dst >`) is the same. So to maintain redability and conciseness, it is merged in one. 

* Moreover, the `pip` command can take [multiple requirement files]( https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-r ) using multiple `-r` tags. So collated the same.

**Main advantage** of collating the above is **reduction in image size** which in turn can be useful for further optimization as the project grows. As there were multiple `COPY` and `RUN` commands, intermidiate **layers** were getting created during docker build which were of no use further and were increasing the image size. So, according to the [best practices]( https://docs.docker.com/develop/dev-best-practices/ ) mentioned in Docker Docs, it should be consolidated as one. ( _We can use '&&' operator with another pip command also instead of passing two requirements file to one pip install command_ )

Kindly consider looking into these and reverting with your views. 